### PR TITLE
adhere to padded-blocks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,6 @@ module.exports = function (files, options, cb) {
 
   // parse ignore patterns into a file list
   if (opts.ignore.length) {
-
     opts.ignore.forEach(function (pattern) {
       debug('scanning for files matching ignore pattern "%s"', pattern)
 

--- a/test/index.js
+++ b/test/index.js
@@ -125,7 +125,6 @@ describe('echint', function () {
       pattern: 'test/fixtures/*',
       readPackage: false
     }, function (errors, valid) {
-
       valid.should.be.false
       errors.should.be.an.Object
 


### PR DESCRIPTION
We are in the process of adding back the rule `padded-blocks` into `standard`. It was temporarily disabled because of a bug in eslint which now has been fixed.

This pull request makes sure that your coding style is compliant with the new version.

Please see feross/standard#170 for more info.
