### PR TITLE
Support sharable configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ Sometimes you need to ignore additional folders or specific minified files. To d
 }
 ```
 
+### Can I use a sharable configuration?
+
+Yes, you may prefer to check your code against a centralized `.editorconfig`. To do that, add a `echint.extends` property to `package.json`:
+
+```json
+"echint": {
+  "extends": "echint-config-some-config"
+}
+```
+
+echint will use the `main` property or `.editorconfig` file from that package as the configuration. The `echint-config-` prefix will be added automatically if it is not already present.
+
 ### use your ENV
 
 echint uses [`dotenv`](https://www.npmjs.com/package/dotenv) to load the following environment config values:

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "babel-register": "^6.18.0",
     "codeclimate-test-reporter": "^0.4.0",
     "cz-conventional-changelog": "^1.2.0",
+    "echint-config-jquery": "^1.0.0",
     "semantic-release": "^6.3.2",
     "snazzy": "^5.0.0",
     "tap": "^8.0.1"

--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,16 @@ export default function (files, options, cb) {
   // overwrite from local options again
   Object.assign(opts, options)
 
+  if (opts.extends) {
+    debug('extends found')
+
+    let extendsDir = path.join(process.cwd(), 'node_modules', opts.extends.replace(/^(echint-config-)?/, 'echint-config-'))
+
+    let extendsMain = pkg('main', { cwd: extendsDir, root: false })
+
+    opts.config = path.join(extendsDir, extendsMain || '.editorconfig')
+  }
+
   debug('starting with options: config=%s ignore=%j', opts.config, opts.ignore)
 
   // parse ignore patterns into a file list

--- a/test/index.js
+++ b/test/index.js
@@ -139,3 +139,15 @@ test('should read from environment variables', (assert) => {
     assert.ok(valid)
   })
 })
+
+test('should read sharable config file', (assert) => {
+  assert.plan(1)
+
+  const result = echint({
+    extends: 'jquery',
+    pattern: 'test/fixtures/*',
+    readPackage
+  })
+
+  assert.ok(result)
+})


### PR DESCRIPTION
A configuration file can extend the set of enabled rules from base
configurations.

1. If an `extends` option is truthy, then;
   1. Declare `opts.config` to be `echint-config-${ extends }`-like.