### PR TITLE
Fix pretest script failing because of echint not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/ahmadnassri/echint/issues"
   },
   "scripts": {
-    "lint": "snazzy && echint",
+    "lint": "snazzy && ./lib/bin.js",
     "pretest": "npm run lint",
     "test": "tap test",
     "coverage": "tap test --reporter silent --coverage"


### PR DESCRIPTION
Because, obviously, it is not declared in dev-dependencies.

Using direct path to lib/bin.js for dogfooding and prevent circular
dependencies.