### PR TITLE
feat(core): let linspaces handle lookup of .editorconfig files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ module.exports = function echint (files, options, cb) {
 
   // default values
   const defaults = {
-    config: process.env.ECHINT_CONFIG || path.join(process.cwd(), '.editorconfig'),
+    config: process.env.ECHINT_CONFIG || '.editorconfig',
     ignore: process.env.ECHINT_IGNORE ? [process.env.ECHINT_IGNORE] : DEFAULT_IGNORE_PATTERNS,
     pattern: process.env.ECHINT_PATTERN || DEFAULT_PATTERN,
     readPackage: process.env.ECHINT_READ_PACKAGE ? (process.env.ECHINT_READ_PACKAGE === 'true') : (options ? options.readPackage : true)


### PR DESCRIPTION
This provides a better matching of files against .editorconfig rules,
making proper lookup and mergin of .editorconfig files, all handled
by schorfES/node-lintspaces and editorconfig/editorconfig-core-js

BREAKING CHANGE: .editorconfig rules matching has been changed so
behaviour might be different in cases where there are nested
.editorconfig files in folder tree.

Closes #59