### PR TITLE
Allow ECHINT_IGNORE env variable to have multiples values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ module.exports = function echint (files, options, cb) {
   // default values
   const defaults = {
     config: process.env.ECHINT_CONFIG || '.editorconfig',
-    ignore: process.env.ECHINT_IGNORE ? process.env.ECHINT_IGNORE.split(",") : DEFAULT_IGNORE_PATTERNS,
+    ignore: process.env.ECHINT_IGNORE ? process.env.ECHINT_IGNORE.split(',') : DEFAULT_IGNORE_PATTERNS,
     pattern: process.env.ECHINT_PATTERN || DEFAULT_PATTERN,
     readPackage: process.env.ECHINT_READ_PACKAGE ? (process.env.ECHINT_READ_PACKAGE === 'true') : (options ? options.readPackage : true)
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ module.exports = function echint (files, options, cb) {
   // default values
   const defaults = {
     config: process.env.ECHINT_CONFIG || '.editorconfig',
-    ignore: process.env.ECHINT_IGNORE ? [process.env.ECHINT_IGNORE] : DEFAULT_IGNORE_PATTERNS,
+    ignore: process.env.ECHINT_IGNORE ? process.env.ECHINT_IGNORE.split(",") : DEFAULT_IGNORE_PATTERNS,
     pattern: process.env.ECHINT_PATTERN || DEFAULT_PATTERN,
     readPackage: process.env.ECHINT_READ_PACKAGE ? (process.env.ECHINT_READ_PACKAGE === 'true') : (options ? options.readPackage : true)
   }


### PR DESCRIPTION
ECHINT_IGNORE cant have multiple values, as process.env variables are strings and without the split you can never pass more than one string to the ignore array.